### PR TITLE
cast key to string

### DIFF
--- a/sweetviz/series_analyzer.py
+++ b/sweetviz/series_analyzer.py
@@ -42,7 +42,7 @@ def fill_out_missing_counts_in_other_series(my_counts:dict, other_counts:dict):
                 # If categorical, must do this hack to add new value
                 if my_counts[to_fill].index.dtype.name == 'category':
                     my_counts[to_fill] = my_counts[to_fill].reindex(my_counts[to_fill].index.add_categories(key))
-                my_counts[to_fill].at[key] = 0
+                my_counts[to_fill].at[str(key)] = 0
 
 def add_series_base_stats_to_dict(series: pd.Series, counts: dict, updated_dict: dict) -> dict:
     updated_dict["stats"] = dict()


### PR DESCRIPTION
In some cases the key is a boolean value  not a string. A keyerror is produced when a boolean value appears in key. Reference #42 

I was able to recreate the issue as user described and was able to fix by casting key as string. It seems like the key should always be a string. 