### PR TITLE
Fix the bug that first bin in histogram always has target zero

### DIFF
--- a/sweetviz/graph_numeric.py
+++ b/sweetviz/graph_numeric.py
@@ -91,8 +91,9 @@ class GraphNumeric(sweetviz.graph.Graph):
                 # TODO: possible 1-off bug in counts from cut in lower bin
                 source_bins_series = pd.cut(to_process.source,
                                             bins=bin_limits,
-                                            labels=False)
-                source_bins_series = source_bins_series.fillna(0)
+                                            labels=False,
+                                            right=False)
+                source_bins_series = source_bins_series.fillna(num_bins-1)
                 # Create empty bin_averages, then fill in with values
                 bin_averages = [None] * num_bins
                 for b in range(0, num_bins):
@@ -111,8 +112,9 @@ class GraphNumeric(sweetviz.graph.Graph):
                     # TARGET NUMERIC: with compare TARGET
                     compare_bins_series = pd.cut(to_process.compare,
                                                 bins=bin_limits,
-                                                labels=False)
-                    compare_bins_series = compare_bins_series.fillna(0)
+                                                labels=False,
+                                                right=False)
+                    source_bins_series = source_bins_series.fillna(num_bins-1)
                     bin_averages = [None] * num_bins
                     for b in range(0, num_bins):
                         bin_averages[b] = \
@@ -124,8 +126,9 @@ class GraphNumeric(sweetviz.graph.Graph):
                 source_true = to_process.source[to_process.source_target == 1]
                 source_bins_series = pd.cut(source_true,
                                             bins=bin_limits,
-                                            labels=False)
-                source_bins_series = source_bins_series.fillna(0)
+                                            labels=False,
+                                            right=False)
+                source_bins_series = source_bins_series.fillna(num_bins-1)
                 total_counts_source = bin_counts[0] if to_process.compare is not None else bin_counts
                 total_counts_source = total_counts_source * len(cleaned_source)
                 bin_true_counts_source = [None] * num_bins
@@ -156,8 +159,9 @@ class GraphNumeric(sweetviz.graph.Graph):
                     # TODO: possible 1-off bug in counts from cut in lower bin
                     compare_bins_series = pd.cut(compare_true,
                                                 bins=bin_limits,
-                                                labels=False)
-                    compare_bins_series = compare_bins_series.fillna(0)
+                                                labels=False,
+                                                right=False)
+                    source_bins_series = source_bins_series.fillna(num_bins-1)
                     total_counts_compare = bin_counts[1] * len(cleaned_compare)
                     bin_true_counts_compare = [None] * num_bins
                     for b in range(0, num_bins):

--- a/sweetviz/graph_numeric.py
+++ b/sweetviz/graph_numeric.py
@@ -92,6 +92,7 @@ class GraphNumeric(sweetviz.graph.Graph):
                 source_bins_series = pd.cut(to_process.source,
                                             bins=bin_limits,
                                             labels=False)
+                source_bins_series = source_bins_series.fillna(0)
                 # Create empty bin_averages, then fill in with values
                 bin_averages = [None] * num_bins
                 for b in range(0, num_bins):
@@ -111,6 +112,7 @@ class GraphNumeric(sweetviz.graph.Graph):
                     compare_bins_series = pd.cut(to_process.compare,
                                                 bins=bin_limits,
                                                 labels=False)
+                    compare_bins_series = compare_bins_series.fillna(0)
                     bin_averages = [None] * num_bins
                     for b in range(0, num_bins):
                         bin_averages[b] = \
@@ -123,6 +125,7 @@ class GraphNumeric(sweetviz.graph.Graph):
                 source_bins_series = pd.cut(source_true,
                                             bins=bin_limits,
                                             labels=False)
+                source_bins_series = source_bins_series.fillna(0)
                 total_counts_source = bin_counts[0] if to_process.compare is not None else bin_counts
                 total_counts_source = total_counts_source * len(cleaned_source)
                 bin_true_counts_source = [None] * num_bins
@@ -154,6 +157,7 @@ class GraphNumeric(sweetviz.graph.Graph):
                     compare_bins_series = pd.cut(compare_true,
                                                 bins=bin_limits,
                                                 labels=False)
+                    compare_bins_series = compare_bins_series.fillna(0)
                     total_counts_compare = bin_counts[1] * len(cleaned_compare)
                     bin_true_counts_compare = [None] * num_bins
                     for b in range(0, num_bins):


### PR DESCRIPTION
The first bin on the left in a histogram sometimes has target value zero. This is because that pandas.cut does not include the left most point in bin_limits and the resulting source_bins_series has NA. To fix it, simply fill the NAs with 0 since they always belong to the first bin.