### PR TITLE
mad replaced with mean_absolute_deviation

### DIFF
--- a/sweetviz/series_analyzer_numeric.py
+++ b/sweetviz/series_analyzer_numeric.py
@@ -22,7 +22,7 @@ def do_stats_numeric(series: pd.Series, updated_dict: dict):
     stats["kurtosis"] = series.kurt()
     stats["skewness"] = series.skew()
     stats["sum"] = series.sum()
-    stats["mad"] = series.mad()
+    stats["mad"] = series.mean_absolute_deviation()
     stats["cv"] = stats["std"] / stats["mean"] if stats["mean"] else np.NaN
     return updated_dict
 


### PR DESCRIPTION
With reference to pandas documentation, mad has been deprecated. https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.mad.html

In this case, we can get the same result by using mean_absolute_deviation

This will make code future safe and prevent warnings like this one:

![mad](https://user-images.githubusercontent.com/5121817/222954560-10600730-8ef2-460c-8766-dfd0eba4ec46.png)
