### PR TITLE
fix #144 and #146 - module 'numpy' has no attribute 'warnings'

### DIFF
--- a/sweetviz/graph_numeric.py
+++ b/sweetviz/graph_numeric.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mtick
+import warnings
 
 from sweetviz.config import config
 from sweetviz import sv_html_formatters
@@ -67,10 +68,10 @@ class GraphNumeric(sweetviz.graph.Graph):
 
         gap_percent = config["Graphs"].getfloat("summary_graph_categorical_gap")
 
-        np.warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
+        warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
         self.hist_specs = axs.hist(plot_data, weights = normalizing_weights, bins=self.num_bins, \
                                    rwidth = (100.0 - gap_percent) / 100.0)
-        np.warnings.filterwarnings('once', category=np.VisibleDeprecationWarning)
+        warnings.filterwarnings('once', category=np.VisibleDeprecationWarning)
 
         bin_limits = self.hist_specs[1]
         num_bins = len(bin_limits) - 1


### PR DESCRIPTION
### Issue
Running the analyze() function in **numpy versions that are >= 1.24** would cause the code to crash since the latest numpy release has dropped the np.warnings from their namespaces and the graph_numeric.py is still using it.

### Fix
However, it appears that **_warnings_** is a built-in in Python thus we can use it without the np.warning and by simply importing warnings and using it directly without numpy. That's all, now we can use sweetviz with newer versions of numpy as well.

### Reference
Numpy github that show's the removal of np.warnings = https://github.com/numpy/numpy/commit/118e6c433a9afdefbfad7652f56e2b97e23bc508
Built-in warnings in python: https://docs.python.org/3/library/warnings.html#overriding-the-default-filter