### PR TITLE
fix: Remove unused distutils import

### DIFF
--- a/sweetviz/series_analyzer.py
+++ b/sweetviz/series_analyzer.py
@@ -5,7 +5,6 @@ import sweetviz.series_analyzer_numeric
 import sweetviz.series_analyzer_cat
 import sweetviz.series_analyzer_text
 
-from distutils.version import LooseVersion
 
 def get_counts(series: pd.Series) -> dict:
     # The value_counts() function is used to get a Series containing counts of unique values.


### PR DESCRIPTION
distutils is deprecated in Python3.12 (ref: https://docs.python.org/3.10/library/distutils.html). 

Since it's not explicitly being used - not sure if it was crucial to the working of any util, perhaps we could use `packaging.version.Version` if it's still needed.


```fish
Python 3.12.4 (main, Jun  6 2024, 18:26:44) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sweetviz
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/gavin/Desktop/v1/maggie#2546/.venv/lib/python3.12/site-packages/sweetviz/__init__.py", line 15, in <module>
    from sweetviz.sv_public import analyze, compare, compare_intra
  File "/home/gavin/Desktop/v1/maggie#2546/.venv/lib/python3.12/site-packages/sweetviz/sv_public.py", line 4, in <module>
    import sweetviz.dataframe_report
  File "/home/gavin/Desktop/v1/maggie#2546/.venv/lib/python3.12/site-packages/sweetviz/dataframe_report.py", line 10, in <module>
    import sweetviz.series_analyzer as sa
  File "/home/gavin/Desktop/v1/maggie#2546/.venv/lib/python3.12/site-packages/sweetviz/series_analyzer.py", line 8, in <module>
    from distutils.version import LooseVersion
ModuleNotFoundError: No module named 'distutils'
```

Distro: NixOS 24.05.3214.575f3027caa1 (Uakari) x86_64