### PR TITLE
Fix visible deprecation warning, pkg_resources deprecation

### DIFF
--- a/sweetviz/graph.py
+++ b/sweetviz/graph.py
@@ -1,24 +1,25 @@
 import matplotlib
-import os.path
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 from io import BytesIO
 import base64
-from pkg_resources import resource_filename
+import importlib_resources
 from pandas.plotting import register_matplotlib_converters
 
 from sweetviz import sv_html_formatters
 from sweetviz.config import config
 
 register_matplotlib_converters()
-#matplotlib.use('SVG')
-#matplotlib.use('tkagg')
-plt.rcParams['svg.fonttype'] = 'path'
+# matplotlib.use('SVG')
+# matplotlib.use('tkagg')
+plt.rcParams["svg.fonttype"] = "path"
 # plt.rcParams['svg.fonttype'] = 'none'
 
 COLOR_TARGET_SOURCE = "#004bd1"
 COLOR_TARGET_COMPARE = "#e54600"
+
 
 class Graph:
     def __init__(self):
@@ -30,23 +31,21 @@ class Graph:
     @staticmethod
     def get_encoded_base64(figure):
         as_raw_bytes = BytesIO()
-        figure.savefig(as_raw_bytes, format='png', transparent=True)
+        figure.savefig(as_raw_bytes, format="png", transparent=True)
         as_raw_bytes.seek(0)
         return base64.b64encode(as_raw_bytes.read())
 
     @staticmethod
     # ADDED can_use_cjk, because the tighter default font is better for numeric graphs
-    def set_style(style_filename_list, can_use_cjk = True):
-        # graph_font_filename = resource_filename(__name__, os.path.join("fonts", "Roboto-Medium.ttf"))
-
-         # WORKAROUND: createFontList deprecation in mpl >=3.2
+    def set_style(style_filename_list, can_use_cjk=True):
+        # WORKAROUND: createFontList deprecation in mpl >=3.2
         if hasattr(fm.fontManager, "addfont"):
-            font_dirs = [resource_filename(__name__, "fonts"), ]
+            font_dirs = (Path(__file__).parent / "fonts",)
             font_files = fm.findSystemFonts(fontpaths=font_dirs)
             for font_found in font_files:
                 fm.fontManager.addfont(font_found)
         else:
-            font_dirs = [resource_filename(__name__, "fonts"), ]
+            font_dirs = (Path(__file__).parent / "fonts",)
             font_files = fm.findSystemFonts(fontpaths=font_dirs)
             font_list = fm.createFontList(font_files)
             fm.fontManager.ttflist.extend(font_list)
@@ -54,8 +53,9 @@ class Graph:
 
         styles_in_final_location = list()
         for source_name in style_filename_list:
-            styles_in_final_location.append(resource_filename(__name__, os.path.join("mpl_styles",
-                                                                                     source_name)))
+            styles_in_final_location.append(
+                Path(__file__).parent / "mpl_styles" / source_name
+            )
         # fm.FontProperties(fname=graph_font_filename)
 
         # Apply style
@@ -63,8 +63,7 @@ class Graph:
 
         # NEW: support for CJK characters, apply override after setting the style
         if config["General"].getint("use_cjk_font") != 0 and can_use_cjk:
-            plt.rcParams['font.family'] = 'Noto Sans CJK JP'
-
+            plt.rcParams["font.family"] = "Noto Sans CJK JP"
 
     @staticmethod
     def format_smart(x, pos=None):

--- a/sweetviz/graph_numeric.py
+++ b/sweetviz/graph_numeric.py
@@ -9,6 +9,7 @@ from sweetviz import sv_html_formatters
 from sweetviz.sv_types import FeatureType, FeatureToProcess
 import sweetviz.graph
 
+
 class GraphNumeric(sweetviz.graph.Graph):
     def __init__(self, which_graph: str, to_process: FeatureToProcess):
         if to_process.is_target() and which_graph == "mini":
@@ -19,14 +20,24 @@ class GraphNumeric(sweetviz.graph.Graph):
 
         is_detail = which_graph.find("detail") != -1
         if which_graph == "mini":
-            f, axs = plt.subplots(1, 1, \
-                                  figsize=(config["Graphs"].getfloat("num_summary_graph_width"),
-                                           config["Graphs"].getfloat("summary_graph_height")))
+            f, axs = plt.subplots(
+                1,
+                1,
+                figsize=(
+                    config["Graphs"].getfloat("num_summary_graph_width"),
+                    config["Graphs"].getfloat("summary_graph_height"),
+                ),
+            )
             self.num_bins = None
         elif is_detail:
-            f, axs = plt.subplots(1, 1, \
-                                  figsize=(config["Graphs"].getfloat("detail_graph_width"),
-                                           config["Graphs"].getfloat("detail_graph_height_numeric")))
+            f, axs = plt.subplots(
+                1,
+                1,
+                figsize=(
+                    config["Graphs"].getfloat("detail_graph_width"),
+                    config["Graphs"].getfloat("detail_graph_height_numeric"),
+                ),
+            )
             split = which_graph.split("-")
             self.index_for_css = split[1]
             self.num_bins = int(split[1])
@@ -38,14 +49,14 @@ class GraphNumeric(sweetviz.graph.Graph):
         else:
             raise ValueError
 
-        axs.tick_params(axis='x', direction='out', pad=2, labelsize=8, length=2)
-        axs.tick_params(axis='y', direction='out', pad=2, labelsize=8, length=2)
+        axs.tick_params(axis="x", direction="out", pad=2, labelsize=8, length=2)
+        axs.tick_params(axis="y", direction="out", pad=2, labelsize=8, length=2)
         axs.xaxis.set_major_formatter(mtick.FuncFormatter(self.format_smart))
         axs.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1.0, decimals=0))
 
         # MAIN DATA ("Under" target)
         # ---------------------------------------------
-        np.seterr(all='raise')
+        np.seterr(all="raise")
         # WORKAROUND histogram warnings
         cleaned_source = to_process.source[~np.isnan(to_process.source)]
         if len(cleaned_source):
@@ -68,10 +79,18 @@ class GraphNumeric(sweetviz.graph.Graph):
 
         gap_percent = config["Graphs"].getfloat("summary_graph_categorical_gap")
 
-        warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
-        self.hist_specs = axs.hist(plot_data, weights = normalizing_weights, bins=self.num_bins, \
-                                   rwidth = (100.0 - gap_percent) / 100.0)
-        warnings.filterwarnings('once', category=np.VisibleDeprecationWarning)
+        warnings.filterwarnings(
+            "ignore", category=np.exceptions.VisibleDeprecationWarning
+        )
+        self.hist_specs = axs.hist(
+            plot_data,
+            weights=normalizing_weights,
+            bins=self.num_bins,
+            rwidth=(100.0 - gap_percent) / 100.0,
+        )
+        warnings.filterwarnings(
+            "once", category=np.exceptions.VisibleDeprecationWarning
+        )
 
         bin_limits = self.hist_specs[1]
         num_bins = len(bin_limits) - 1
@@ -80,7 +99,10 @@ class GraphNumeric(sweetviz.graph.Graph):
         # Format x ticks
         x_ticks = plt.xticks()
         # tick_range = max(x_ticks[0]) - min(x_ticks[0])
-        new_labels = [sv_html_formatters.fmt_smart_range_tight(val, max(x_ticks[0])) for val in x_ticks[0]]
+        new_labels = [
+            sv_html_formatters.fmt_smart_range_tight(val, max(x_ticks[0]))
+            for val in x_ticks[0]
+        ]
         plt.xticks(x_ticks[0], new_labels)
 
         # TARGET
@@ -90,54 +112,66 @@ class GraphNumeric(sweetviz.graph.Graph):
                 # TARGET: IS NUMERIC
                 # Create a series where each item indicates its bin
                 # TODO: possible 1-off bug in counts from cut in lower bin
-                source_bins_series = pd.cut(to_process.source,
-                                            bins=bin_limits,
-                                            labels=False,
-                                            right=False)
-                source_bins_series = source_bins_series.fillna(num_bins-1)
+                source_bins_series = pd.cut(
+                    to_process.source, bins=bin_limits, labels=False, right=False
+                )
+                source_bins_series = source_bins_series.fillna(num_bins - 1)
                 # Create empty bin_averages, then fill in with values
                 bin_averages = [None] * num_bins
                 for b in range(0, num_bins):
-                    bin_averages[b] = \
-                        to_process.source_target[source_bins_series == b].mean()
+                    bin_averages[b] = to_process.source_target[
+                        source_bins_series == b
+                    ].mean()
 
                 # TODO: verify number of bins
                 bin_offset_x = (bin_limits[1] - bin_limits[0]) / 2.0
                 ax2 = axs.twinx()
                 ax2.yaxis.set_major_formatter(mtick.FuncFormatter(self.format_smart))
-                ax2.plot(bin_limits[:-1] + bin_offset_x, bin_averages, \
-                         marker='o', color=sweetviz.graph.COLOR_TARGET_SOURCE)
+                ax2.plot(
+                    bin_limits[:-1] + bin_offset_x,
+                    bin_averages,
+                    marker="o",
+                    color=sweetviz.graph.COLOR_TARGET_SOURCE,
+                )
 
-                if to_process.compare is not None and \
-                        to_process.compare_target is not None:
+                if (
+                    to_process.compare is not None
+                    and to_process.compare_target is not None
+                ):
                     # TARGET NUMERIC: with compare TARGET
-                    compare_bins_series = pd.cut(to_process.compare,
-                                                bins=bin_limits,
-                                                labels=False,
-                                                right=False)
-                    source_bins_series = source_bins_series.fillna(num_bins-1)
+                    compare_bins_series = pd.cut(
+                        to_process.compare, bins=bin_limits, labels=False, right=False
+                    )
+                    source_bins_series = source_bins_series.fillna(num_bins - 1)
                     bin_averages = [None] * num_bins
                     for b in range(0, num_bins):
-                        bin_averages[b] = \
-                            to_process.compare_target[compare_bins_series == b].mean()
-                    ax2.plot(bin_limits[:-1] + bin_offset_x, bin_averages, \
-                             marker='o', color=sweetviz.graph.COLOR_TARGET_COMPARE)
+                        bin_averages[b] = to_process.compare_target[
+                            compare_bins_series == b
+                        ].mean()
+                    ax2.plot(
+                        bin_limits[:-1] + bin_offset_x,
+                        bin_averages,
+                        marker="o",
+                        color=sweetviz.graph.COLOR_TARGET_COMPARE,
+                    )
             elif to_process.predetermined_type_target == FeatureType.TYPE_BOOL:
                 # TARGET: IS BOOL
                 source_true = to_process.source[to_process.source_target == 1]
-                source_bins_series = pd.cut(source_true,
-                                            bins=bin_limits,
-                                            labels=False,
-                                            right=False)
-                source_bins_series = source_bins_series.fillna(num_bins-1)
-                total_counts_source = bin_counts[0] if to_process.compare is not None else bin_counts
+                source_bins_series = pd.cut(
+                    source_true, bins=bin_limits, labels=False, right=False
+                )
+                source_bins_series = source_bins_series.fillna(num_bins - 1)
+                total_counts_source = (
+                    bin_counts[0] if to_process.compare is not None else bin_counts
+                )
                 total_counts_source = total_counts_source * len(cleaned_source)
                 bin_true_counts_source = [None] * num_bins
                 for b in range(0, num_bins):
                     if total_counts_source[b] > 0:
-                        bin_true_counts_source[b] = \
-                            source_true[source_bins_series == b].count() \
+                        bin_true_counts_source[b] = (
+                            source_true[source_bins_series == b].count()
                             / total_counts_source[b]
+                        )
                     else:
                         bin_true_counts_source[b] = None
                 # TODO: verify number of bins
@@ -147,35 +181,47 @@ class GraphNumeric(sweetviz.graph.Graph):
                 # Share % axis
                 # ax2 = axs.twinx()
                 ax2 = axs
-                ax2.yaxis.set_major_formatter(mtick.PercentFormatter(xmax=1.0, decimals=0))
-                ax2.plot(bin_limits[:-1] + bin_offset_x, bin_true_counts_source, \
-                         marker='o', color=sweetviz.graph.COLOR_TARGET_SOURCE)
+                ax2.yaxis.set_major_formatter(
+                    mtick.PercentFormatter(xmax=1.0, decimals=0)
+                )
+                ax2.plot(
+                    bin_limits[:-1] + bin_offset_x,
+                    bin_true_counts_source,
+                    marker="o",
+                    color=sweetviz.graph.COLOR_TARGET_SOURCE,
+                )
 
-                if to_process.compare is not None and \
-                        to_process.compare_target is not None:
+                if (
+                    to_process.compare is not None
+                    and to_process.compare_target is not None
+                ):
                     # TARGET BOOL: with compare TARGET
                     compare_true = to_process.compare[to_process.compare_target == 1]
 
                     # Create a series where each item indicates its bin
                     # TODO: possible 1-off bug in counts from cut in lower bin
-                    compare_bins_series = pd.cut(compare_true,
-                                                bins=bin_limits,
-                                                labels=False,
-                                                right=False)
-                    source_bins_series = source_bins_series.fillna(num_bins-1)
+                    compare_bins_series = pd.cut(
+                        compare_true, bins=bin_limits, labels=False, right=False
+                    )
+                    source_bins_series = source_bins_series.fillna(num_bins - 1)
                     total_counts_compare = bin_counts[1] * len(cleaned_compare)
                     bin_true_counts_compare = [None] * num_bins
                     for b in range(0, num_bins):
                         if total_counts_compare[b] > 0:
-                            bin_true_counts_compare[b] = \
-                                compare_true[compare_bins_series == b].count() \
-                                    / total_counts_compare[b]
+                            bin_true_counts_compare[b] = (
+                                compare_true[compare_bins_series == b].count()
+                                / total_counts_compare[b]
+                            )
                         else:
                             bin_true_counts_compare[b] = None
 
-                    ax2.plot(bin_limits[:-1] + bin_offset_x, bin_true_counts_compare, \
-                             marker='o', color=sweetviz.graph.COLOR_TARGET_COMPARE)
-                ax2.set_ylim([0,None])
+                    ax2.plot(
+                        bin_limits[:-1] + bin_offset_x,
+                        bin_true_counts_compare,
+                        marker="o",
+                        color=sweetviz.graph.COLOR_TARGET_COMPARE,
+                    )
+                ax2.set_ylim([0, None])
 
                 # elif to_process.compare is not None:
                 #     # TARGET BOOL: only on source, but there's a compare
@@ -209,7 +255,7 @@ class GraphNumeric(sweetviz.graph.Graph):
         # -----------------------------
         self.size_in_inches = f.get_size_inches()
         if which_graph == "mini":
-            needed_pixels_padding = np.array([4.0, 32, 15, 45]) # TOP-LEFT-BOTTOM-RIGHT
+            needed_pixels_padding = np.array([4.0, 32, 15, 45])  # TOP-LEFT-BOTTOM-RIGHT
         else:
             needed_pixels_padding = np.array([5.0, 32, 15, 45])  # TOP-LEFT-BOTTOM-RIGHT
         padding_fraction = needed_pixels_padding
@@ -217,10 +263,14 @@ class GraphNumeric(sweetviz.graph.Graph):
         padding_fraction[2] = padding_fraction[2] / (self.size_in_inches[1] * f.dpi)
         padding_fraction[3] = padding_fraction[3] / (self.size_in_inches[0] * f.dpi)
         padding_fraction[1] = padding_fraction[1] / (self.size_in_inches[0] * f.dpi)
-        plt.subplots_adjust(top=(1.0 - padding_fraction[0]), left=padding_fraction[1], \
-                bottom=padding_fraction[2], right=(1.0 - padding_fraction[3]))
+        plt.subplots_adjust(
+            top=(1.0 - padding_fraction[0]),
+            left=padding_fraction[1],
+            bottom=padding_fraction[2],
+            right=(1.0 - padding_fraction[3]),
+        )
         self.graph_base64 = self.get_encoded_base64(f)
-        plt.close('all')
-        #plt.close(f)
+        plt.close("all")
+        # plt.close(f)
         # print(matplotlib.rcParams)
         return


### PR DESCRIPTION
This should fix https://github.com/fbdesignpro/sweetviz/issues/174 and the rejuvenated discussion around https://github.com/fbdesignpro/sweetviz/issues/144#issuecomment-2333936782. In testing that, I found that pkg_resources was deprecated and failing, so I replaced that code with a pathlib equivalent.

A minimal test is

```
import pandas as pd
import sweetviz as sv
iris = pd.read_csv('https://raw.githubusercontent.com/mwaskom/seaborn-data/master/iris.csv')
report = sv.analyze(iris)
report.show_html()
```